### PR TITLE
Fix dependencies in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,12 @@ keywords = [
 
 # TODO: check requirements
 
-[options]
-install_requires = [
-  "opensees",
+dependencies = [
+  "opensees[py]",
   "numpy",
   "scipy",
   "sympy",
-  "sees",
-  "matplotlib",
+  "matplotlib"
 ]
 
 [project.urls]


### PR DESCRIPTION
Apparently the `pyproject.toml` I copied in used an obsolete field for specifying dependencies. This is the right way.